### PR TITLE
Fix parsing of UInt64 values

### DIFF
--- a/src/LitJson/JsonReader.cs
+++ b/src/LitJson/JsonReader.cs
@@ -289,6 +289,16 @@ namespace LitJson
 
                 return;
             }
+            
+            ulong n_uint64;
+            if (UInt64.TryParse(number, out n_uint64))
+            {
+                token = JsonToken.Long;
+                token_value = n_uint64;
+
+                return;
+            }
+            
 
             // Shouldn't happen, but just in case, return something
             token = JsonToken.Int;


### PR DESCRIPTION
For reading unsigned long (UInt64) type data, 
added some code to pass ValueTypesTest's ulong with max value.
