### PR TITLE
Add make variable for specifying pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ If you have
 system, and the *Mono* suite provides the `mono-nunit.pc` file, you can try
 running these tests by running `make test` from the `build/make` directory.
 
+You can specify which `pkg-config` is invoked by passing a `PKG_CONFIG`
+variable to `make test`. This is useful when you have mutiple conflicting
+`pkg-config`s on your system and need to select the correct one (i.e. to
+avoid conflicts with Homebrew on Mac OSX).
+
+Example of running the tests on Mac OSX:
+
+```bash
+# In litjson/ directory
+$ cd build/make
+$ make PKG_CONFIG=/Library/Frameworks/Mono.framework/Commands/pkg-config test
+```
 
 ## Using LitJSON from an application
 

--- a/build/make/Makefile
+++ b/build/make/Makefile
@@ -9,7 +9,7 @@ CSC = gmcs
 CSC_FLAGS =
 DATA_VERSION = $(topdir)/build/version
 NUNIT = nunit-console2
-MONO_PKG_CONFIG = pkg-config
+PKG_CONFIG = pkg-config
 
 
 ifdef ENABLE_DEBUG
@@ -45,7 +45,7 @@ CLEAN_FILES += $(LITJSON_ASSEMBLY) $(GEN_FILES) $(LITJSON_MDB_FILE)
 ##
 TEST_ASSEMBLY = $(topdir)/bin/LitJson.Tests.dll
 
-TEST_MONO_NUNIT = $(shell "$(MONO_PKG_CONFIG)" --libs mono-nunit)
+TEST_MONO_NUNIT = $(shell "$(PKG_CONFIG)" --libs mono-nunit)
 
 TEST_RES_FILES = $(testdir)/json-example.txt
 TEST_SRC_FILES = \


### PR DESCRIPTION
Mono ships its own pkg-config which knows about all of its tools, such as nunit-console2. It doesn't really play nice with Mac and Homebrew, so many leave it out of their path.

This change lets you run tests from a terminal on Mac like so:

```
$ make MONO_PKG_CONFIG=/Library/Frameworks/Mono.framework/Commands/pkg-config test
```
