### PR TITLE
Option to force DateTimes to deserialize as Utc

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -97,9 +97,19 @@ namespace LitJson
     public delegate IJsonWrapper WrapperFactory ();
 
 
+    [Flags]
+    public enum JsonMapperOptions
+    {
+	None = 0x00,
+	DateTimesAlwaysUniversal = 0x01,
+    }
+
+
     public class JsonMapper
     {
         #region Fields
+	public static JsonMapperOptions Options;
+
         private static int max_nesting_depth;
 
         private static IFormatProvider datetime_format;
@@ -667,7 +677,11 @@ namespace LitJson
                               typeof (char), importer);
 
             importer = delegate (object input) {
-                return Convert.ToDateTime ((string) input, datetime_format);
+		DateTime result = Convert.ToDateTime((string) input, datetime_format);
+		if ((JsonMapper.Options & JsonMapperOptions.DateTimesAlwaysUniversal) != 0) {
+		    result = result.ToUniversalTime();
+		}
+		return result;
             };
             RegisterImporter (base_importers_table, typeof (string),
                               typeof (DateTime), importer);

--- a/test/JsonMapperTest.cs
+++ b/test/JsonMapperTest.cs
@@ -196,6 +196,11 @@ namespace LitJson.Test
         TestVal2 = 2
     }
 
+    public class DateTimeTest
+    {
+	    public DateTime dateTimeValue;
+    }
+
     public class NullableEnumTest
     {
         public NullableEnum? TestEnum;
@@ -1024,5 +1029,27 @@ namespace LitJson.Test
             expectedJson = "{\"TestEnum\":null}";
             Assert.AreEqual(expectedJson, JsonMapper.ToJson(value));
         }
+
+        [Test]
+        public void DateTimeShouldBeUniversalTest()
+        {
+            string json = @"{
+                ""dateTimeValue"": ""2014-05-02T05:52:10.569000+00:00""
+            }";
+
+            JsonMapper.Options = JsonMapperOptions.DateTimesAlwaysUniversal;
+
+            DateTimeTest dateTimeTest = JsonMapper.ToObject<DateTimeTest>(json);
+            Assert.AreEqual(DateTimeKind.Utc, dateTimeTest.dateTimeValue.Kind);
+
+            json = @"{
+                            ""dateTimeValue"": ""2014-05-02T05:52:10.569000""
+                        }";
+
+            dateTimeTest = JsonMapper.ToObject<DateTimeTest>(json);
+            Assert.AreEqual(DateTimeKind.Utc, dateTimeTest.dateTimeValue.Kind);
+
+            JsonMapper.Options = JsonMapperOptions.None;
+        }	
     }
 }


### PR DESCRIPTION
Things got a little messy in the last version of this PR (#20), so it seemed easier to just rebase from upstream/master and try again.

Here's the notes copied from there:

> The default DateTime deserialization will set the DateTimeKind to Local if there's timezone information in the string. This makes sense, but timezones are a >PITA to manage, and being able to guarantee everything comes out as UTC is pretty important (to me, at least).
> 
> Adds JsonMapperOptions flags enum, and a static Options member in the JsonMapper class.
> 
> The behavior is enabled by a global flag which is a little gross, so maybe some sort of JsonMapper context could be useful in the future.
