### PR TITLE
Force Invariant Culture in JsonReader.cs

### DIFF
--- a/src/LitJson/JsonReader.cs
+++ b/src/LitJson/JsonReader.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -261,12 +262,17 @@ namespace LitJson
         #region Private Methods
         private void ProcessNumber (string number)
         {
+            // Force Invariant Culture for parsing doubles. Prevents issues in
+            // system cultures like fr-FR where Double.TryParse fails to parse
+            // and Int is returned because it was expecting a comma, not a period.
+            CultureInfo culture = CultureInfo.GetCultureInfo (String.Empty);
+
             if (number.IndexOf ('.') != -1 ||
                 number.IndexOf ('e') != -1 ||
                 number.IndexOf ('E') != -1) {
 
                 double n_double;
-                if (Double.TryParse (number, out n_double)) {
+                if (Double.TryParse (number, NumberStyles.Any, culture, out n_double)) {
                     token = JsonToken.Double;
                     token_value = n_double;
 
@@ -275,7 +281,7 @@ namespace LitJson
             }
 
             int n_int32;
-            if (Int32.TryParse (number, out n_int32)) {
+            if (Int32.TryParse (number, NumberStyles.Any, culture, out n_int32)) {
                 token = JsonToken.Int;
                 token_value = n_int32;
 
@@ -283,7 +289,7 @@ namespace LitJson
             }
 
             long n_int64;
-            if (Int64.TryParse (number, out n_int64)) {
+            if (Int64.TryParse (number, NumberStyles.Any, culture, out n_int64)) {
                 token = JsonToken.Long;
                 token_value = n_int64;
 
@@ -291,8 +297,7 @@ namespace LitJson
             }
 
             ulong n_uint64;
-            if (UInt64.TryParse(number, out n_uint64))
-            {
+            if (UInt64.TryParse (number, NumberStyles.Any, culture, out n_uint64)) {
                 token = JsonToken.Long;
                 token_value = n_uint64;
 


### PR DESCRIPTION
Double.TryParse fails in locales that use commas instead of periods.
