### PR TITLE
Add .NET Framework 2.0 as a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ LitJSON currently targets and supports
 * .NET Standard 2.0
 * .NET Standard 1.5
 * .NET Framework 4.5 and above
+* .NET Framework 4.0
+* .NET Framework 3.5 (including SQLCLR, for which [WCOMAB/SqlServerSlackAPI](https://github.com/WCOMAB/SqlServerSlackAPI) is an example of)
+* .NET Framework 2.0
 * Mono 4.4.2 and above
-
-But the code is very portable and can even be compiled under SQLCLR, which [WCOMAB/SqlServerSlackAPI](https://github.com/WCOMAB/SqlServerSlackAPI) is an example of.
 
 #### Prereleases
 

--- a/src/LitJson/LitJSON.csproj
+++ b/src/LitJson/LitJSON.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45;netstandard1.5;net40;net35</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;netstandard1.5;net40;net35;net20</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,6 +29,11 @@ It's quick and lean, without external dependencies.</Description>
     <RepositoryType>git</RepositoryType>
     <PackageTags>JSON;Serializer</PackageTags>
     <IncludeSource>true</IncludeSource>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net20' ">
+    <DefineConstants>$(DefineConstants);LEGACY</DefineConstants>
+    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net20' and '$(OS)' == 'Windows_NT'">C:\Windows\Microsoft.NET\Framework\v2.0.50727</FrameworkPathOverride>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net35' ">


### PR DESCRIPTION
As discussed in #72 , as there is nothing in the source code that should prevent having a .NET 2.0 build of the library, better have .NET Framework 2.0 supported in NuGet.