### PR TITLE
fix singleton object serialization exception

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -832,11 +832,11 @@ namespace LitJson
                 }
                 else {
                     PropertyInfo p_info = (PropertyInfo) p_data.Info;
+                    object prop_obj = p_info.GetValue(obj, null);
 
-                    if (p_info.CanRead) {
+                    if (prop_obj != obj && p_info.CanRead) {
                         writer.WritePropertyName (p_data.Info.Name);
-                        WriteValue (p_info.GetValue (obj, null),
-                                    writer, writer_is_private, depth + 1);
+                        WriteValue (prop_obj, writer, writer_is_private, depth + 1);
                     }
                 }
             }


### PR DESCRIPTION
if prop object is the same as current object, just ignore it to avoid infinite recursion.

please refer to the following issue:
JsonMapper not working for singleton class #100