### PR TITLE
Fix empty array ToJson issues

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -405,6 +405,8 @@ namespace LitJson
                     list = new ArrayList ();
                     elem_type = inst_type.GetElementType ();
                 }
+                
+                list.Clear();
 
                 while (true) {
                     object item = ReadValue (elem_type, reader);

--- a/test/JsonMapperTest.cs
+++ b/test/JsonMapperTest.cs
@@ -202,6 +202,17 @@ namespace LitJson.Test
         public NullableEnum? TestEnum;
     }
 
+    class EmptyArrayInJsonDataTest
+    {
+        public int[] array;
+        public string name;
+    }
+
+    class EmptyArrayInJsonDataTestWrapper
+    {
+        public JsonData data;
+    }
+
     [TestFixture]
     public class JsonMapperTest
     {
@@ -1059,5 +1070,23 @@ namespace LitJson.Test
             expectedJson = "{\"TestEnum\":null}";
             Assert.AreEqual(expectedJson, JsonMapper.ToJson(value));
         }
+        
+        [Test]
+        public void EmptyArrayInJsonDataExportTest()
+        {
+            string testJson = @"
+            {
+                ""data"":
+                {
+                    ""array"": [],
+                    ""name"": ""testName""
+                }
+            }";
+            
+            var response = JsonMapper.ToObject<EmptyArrayInJsonDataTestWrapper>(testJson);
+            var toJsonResult = response.data.ToJson();
+            string expectedJson = "{\"array\":[],\"name\":\"testName\"}";
+            Assert.AreEqual(toJsonResult, expectedJson);
+        }        
     }
 }


### PR DESCRIPTION
#38 #98 bug still remain after 9a2605b commit

I add code `IList.Clear` at the begining of parsing Array to Call inner method, `IList.EnsureList()`.

and add test case which is made possible by this fix.