### PR TITLE
fixed c# dictionary deseriead failed, the string key can't convert to…

### DIFF
--- a/src/LitJson/JsonMapper.cs
+++ b/src/LitJson/JsonMapper.cs
@@ -473,9 +473,24 @@ namespace LitJson
                             }
                         }
 
+                        object cvtVal = null;
+                        Type[] arguments = value_type.GetGenericArguments();
+                        Type keyType = arguments[0];
+                        Type valType = arguments[1];
+                        try
+                        {
+                            cvtVal = Convert.ChangeType(property, keyType);
+                        }
+                        catch (Exception ex)
+                        {
+                            throw new JsonException(String.Format(
+                                       "The key '{0}' can not convert to " +
+                                       " value {1}",
+                                       property, keyType));
+                        }
                         ((IDictionary) instance).Add (
-                            property, ReadValue (
-                                t_data.ElementType, reader));
+                            cvtVal, ReadValue (
+                                valType, reader));
                     }
 
                 }


### PR DESCRIPTION
because of that the all dictionary key has been convert to string , there is an issue which string key can't convert to correct key type of dictionary when deseriead from json, so  i fixed it for my use, maybe there is some mistake  .  you can modify